### PR TITLE
fix: move form state update before fields update

### DIFF
--- a/src/components/Form/Form.tsx
+++ b/src/components/Form/Form.tsx
@@ -91,7 +91,6 @@ function FormComponent(props: FormProps) {
         }
       }
     );
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [props.fields]);
 
   return (

--- a/src/components/Form/Form.tsx
+++ b/src/components/Form/Form.tsx
@@ -42,6 +42,17 @@ function FormComponent(props: FormProps) {
   const [fields, setFields] = useState<Field[]>([]);
 
   useEffect(() => {
+    if (fields.length > 0) {
+      let tmpFields = [...fields];
+      tmpFields = tmpFields.map((item) => {
+        item.value = form.watch(item.id) ?? "";
+        return item;
+      });
+      setFields(tmpFields);
+    }
+  }, [form]);
+
+  useEffect(() => {
     let params = [...props.fields];
     let tmpFields = params.map((param) => {
       register(param.id);
@@ -82,17 +93,6 @@ function FormComponent(props: FormProps) {
     );
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [props.fields]);
-
-  useEffect(() => {
-    if (fields.length > 0) {
-      let tmpFields = [...fields];
-      tmpFields = tmpFields.map((item) => {
-        item.value = form.watch(item.id) ?? "";
-        return item;
-      });
-      setFields(tmpFields);
-    }
-  }, [form]);
 
   return (
     <FormContext.Provider

--- a/src/components/FormField/FormField.test.tsx
+++ b/src/components/FormField/FormField.test.tsx
@@ -19,6 +19,7 @@ import userEvent from "@testing-library/user-event";
 import FormField from "./FormField";
 import { Form } from "../Form";
 import { TestFormConfigProvider } from "../Form/Form.test";
+import { Field } from "../../types";
 
 const fields = [
   {
@@ -78,5 +79,78 @@ describe("FormField", () => {
     expect(getByTestId("name")).toBeInTheDocument();
     await userEvent.type(getByTestId("name"), "User");
     expect(onChange).toBeCalled();
+  });
+
+  test("should render element with updated values and props", async () => {
+    let fields = [
+      {
+        default: null,
+        helper_text: null,
+        id: "select",
+        label: "Select",
+        max_length: null,
+        min_length: null,
+        multiple: false,
+        required: false,
+        type: "string",
+        values: [{ value: 0, label: "Item 0" }],
+      },
+    ];
+
+    const mockRender = jest.fn();
+    const ComponentForm = ({ fields }: { fields: Field[] }) => (
+      <Form fields={fields}>
+        <FormField
+          id={"select"}
+          render={(renderProps) => {
+            delete renderProps.onChange;
+            return mockRender(renderProps);
+          }}
+        />
+        <button data-testid="form-submit" type="submit">
+          Submit
+        </button>
+      </Form>
+    );
+    const { rerender } = render(<ComponentForm fields={fields} />);
+
+    const newFields = [
+      {
+        default: null,
+        helper_text: null,
+        id: "select",
+        label: "Select",
+        max_length: null,
+        min_length: null,
+        multiple: false,
+        required: true,
+        type: "string",
+        values: [
+          { value: 0, label: "Item 0" },
+          { value: 1, label: "Item 1" },
+          { value: 2, label: "Item 2" },
+        ],
+      },
+    ];
+
+    rerender(<ComponentForm fields={newFields} />);
+
+    expect(mockRender).toHaveBeenLastCalledWith({
+      default: null,
+      helper_text: null,
+      id: "select",
+      label: "Select",
+      max_length: null,
+      min_length: null,
+      multiple: false,
+      required: true,
+      type: "string",
+      value: "",
+      values: [
+        { label: "Item 0", value: 0 },
+        { label: "Item 1", value: 1 },
+        { label: "Item 2", value: 2 },
+      ],
+    });
   });
 });


### PR DESCRIPTION
# Description

Move formState update before fields update. This permit the correct update of the fields on form.