### PR TITLE
fix: add props on react childs components

### DIFF
--- a/.changeset/six-badgers-eat.md
+++ b/.changeset/six-badgers-eat.md
@@ -1,0 +1,5 @@
+---
+"@arkejs/form": patch
+---
+
+add props on childs react components

--- a/apps/storybook/src/stories/Form.stories.tsx
+++ b/apps/storybook/src/stories/Form.stories.tsx
@@ -334,11 +334,13 @@ export const WithInternalDependency = () => {
   );
 };
 
+type SubComponentProps = { isTest: boolean; methods: any };
 export const WithCustomFieldComponent = () => {
   const { methods } = useForm();
   const [submitData, setSubmitData] = useState({});
 
-  const TestSubComponent = () => {
+  const TestSubComponent = (props: SubComponentProps) => {
+    console.log("TestSubComponentProps", props);
     return (
       <>
         <div>
@@ -349,14 +351,15 @@ export const WithCustomFieldComponent = () => {
     );
   };
 
-  const TestComponent = () => {
+  const TestComponent = (props: SubComponentProps) => {
+    console.log("TestComponentProps", props);
     return (
       <>
         <div>
           <div>Name</div>
           <Form.Field id="name" />
         </div>
-        <TestSubComponent />
+        <TestSubComponent {...props} />
       </>
     );
   };
@@ -369,7 +372,7 @@ export const WithCustomFieldComponent = () => {
           fields={fields}
           onSubmit={(values) => setSubmitData(values)}
         >
-          <TestComponent />
+          <TestComponent isTest methods={methods} />
           <button style={{ marginTop: 20 }}>Submit</button>
         </Form>
       </GeneralFormProvider>

--- a/packages/form/src/components/Form/Form.tsx
+++ b/packages/form/src/components/Form/Form.tsx
@@ -63,7 +63,7 @@ function FormComponent({
 
           if (typeof reactChild.type === "function") {
             // @ts-ignore: This expression is not callable
-            let children = reactChild.type();
+            let children = reactChild.type(reactChild.props);
             return buildChildren(children);
           }
 


### PR DESCRIPTION
## Description

With this PR the childs components can receive now the props:

```
const TestComponent = (props: SubComponentProps) => {
    console.log(props); -> this receive additional props (ex. methods, isTest)
    return (
      <>
         <Form.Field id="name" />
         <TestSubComponent {...props} />
      </>
    );
  };

return(
   <Form methods={methods} fields={fields} onSubmit={(values) => setSubmitData(values)} >
         <TestComponent isTest methods={methods} />
         <button style={{ marginTop: 20 }}>Submit</button>
   </Form>
)
```