### PR TITLE
feat: add rules and validation props on Controller

### DIFF
--- a/.changeset/good-tips-compete.md
+++ b/.changeset/good-tips-compete.md
@@ -1,0 +1,5 @@
+---
+"@arkejs/form": minor
+---
+
+Add rules and validation on Controller

--- a/apps/storybook/src/stories/Form.stories.tsx
+++ b/apps/storybook/src/stories/Form.stories.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { ReactNode, useEffect, useState } from "react";
 import { Form, FormConfigProvider, useForm, Field } from "@arkejs/form";
 import {
   fields,
@@ -378,6 +378,69 @@ export const WithCustomFieldComponent = () => {
       </GeneralFormProvider>
       <br />
       {JSON.stringify(submitData)}
+    </>
+  );
+};
+
+export const WithRulesValidation = () => {
+  const { methods } = useForm();
+  const {
+    formState: { errors },
+  } = methods;
+
+  const ValidationWrapper = ({
+    id,
+    children,
+  }: {
+    id: string;
+    children: ReactNode;
+  }) => (
+    <div>
+      {children}
+      <div style={Boolean(errors[id]) ? { color: "red" } : {}}>
+        {errors[id]?.message as string}
+      </div>
+    </div>
+  );
+
+  return (
+    <>
+      <GeneralFormProvider>
+        <Form
+          methods={methods}
+          fields={fields}
+          onSubmit={(values) => console.log(values)}
+        >
+          <div>
+            <ValidationWrapper id="name">
+              <div>Name</div>
+              <Form.Field
+                id="name"
+                rules={{
+                  required: "Name is required",
+                }}
+              />
+            </ValidationWrapper>
+            <ValidationWrapper id="email">
+              <div>Email</div>
+              <Form.Field
+                id="email"
+                rules={{
+                  required: "Email is required",
+                  minLength: {
+                    value: 4,
+                    message: "Minimum length is 4",
+                  },
+                  validate: (v) =>
+                    /^\w+([.-]?\w+)*@\w+([.-]?\w+)*(\.\w{2,3})+$/.test(v) ||
+                    "Email address must be a valid address",
+                }}
+              />
+            </ValidationWrapper>
+          </div>
+          <button style={{ marginTop: 20 }}>Submit</button>
+        </Form>
+      </GeneralFormProvider>
     </>
   );
 };

--- a/packages/form/src/components/FormField/FormField.tsx
+++ b/packages/form/src/components/FormField/FormField.tsx
@@ -20,7 +20,16 @@ import { FieldType } from "../../types";
 import { useCallback } from "react";
 import { RenderProps } from "../../types/render";
 
-function FormField({ components, render, fields, id, ...props }: FieldProps) {
+function FormField(props: FieldProps) {
+  const {
+    components,
+    render,
+    fields,
+    id,
+    rules,
+    defaultValue,
+    shouldUnregister,
+  } = props;
   const { control } = useFormContext();
 
   const field = fields?.find((item) => item.id === id);
@@ -43,6 +52,10 @@ function FormField({ components, render, fields, id, ...props }: FieldProps) {
 
   return (
     <Controller
+      name={id}
+      rules={rules}
+      defaultValue={defaultValue}
+      shouldUnregister={shouldUnregister}
       control={control}
       render={(params) => {
         return (
@@ -61,7 +74,6 @@ function FormField({ components, render, fields, id, ...props }: FieldProps) {
           }) ?? <></>
         );
       }}
-      name={id}
     />
   );
 }

--- a/packages/form/src/components/FormField/FormField.tsx
+++ b/packages/form/src/components/FormField/FormField.tsx
@@ -20,16 +20,16 @@ import { FieldType } from "../../types";
 import { useCallback } from "react";
 import { RenderProps } from "../../types/render";
 
-function FormField(props: FieldProps) {
-  const {
-    components,
-    render,
-    fields,
-    id,
-    rules,
-    defaultValue,
-    shouldUnregister,
-  } = props;
+function FormField({
+  components,
+  render,
+  fields,
+  id,
+  rules,
+  defaultValue,
+  shouldUnregister,
+  ...props
+}: FieldProps) {
   const { control } = useFormContext();
 
   const field = fields?.find((item) => item.id === id);

--- a/packages/form/src/components/FormField/FormField.types.ts
+++ b/packages/form/src/components/FormField/FormField.types.ts
@@ -16,8 +16,12 @@
 
 import { Field } from "../../types";
 import { FormProps } from "../Form/Form.types";
+import { UseControllerProps } from "react-hook-form";
 
 type FieldProps = Field<{ [key: string]: any }> &
-  Pick<FormProps, "components" | "fields" | "onChange"> & {};
+  Pick<
+    FormProps,
+    "components" | "fields" | "onChange"
+  > & {} & Partial<UseControllerProps>;
 
 export type { FieldProps };


### PR DESCRIPTION
## Description

Add rules and validation props on Controller. With this PR is possible pass the `rules` props to get validation on FormField, this is passed on Controller.

```
<Form.Field
      id="email"
      rules={{
      required: "Email is required",
      minLength: {
            value: 4,
            message: "Minimum length is 4",
      },
      validate: (v) =>
            /^\w+([.-]?\w+)*@\w+([.-]?\w+)*(\.\w{2,3})+$/.test(v) ||
            "Email address must be a valid address",
      }}
/>
```